### PR TITLE
Remove 'type' for scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ At a high level, here's what you'll accomplish in this tutorial:
 First, include Stripe.js and Quaderno.js in the page:
 
 ```
-<script type="text/javascript" src="https://js.stripe.com/v2/"></script>
-<script type="text/javascript" src="http://js.quaderno.io/v1/"></script>
+<script src="https://js.stripe.com/v2/"></script>
+<script src="http://js.quaderno.io/v1/"></script>
 ```
 
 To prevent problems with some older browsers, we recommend putting the script tag in the `<head>` tag of your page, or as a direct descendant of the `<body>` at the end of your page.


### PR DESCRIPTION
JS is default in all browsers (even older ones) and it's officially specified in HTML5
